### PR TITLE
Integrate auth and request validation middleware

### DIFF
--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -7,7 +7,7 @@ import { eq } from "drizzle-orm";
 
 dotenv.config();
 
-interface AuthenticatedRequest extends Request {
+export interface AuthenticatedRequest extends Request {
   user?: JwtPayload;
 }
 

--- a/src/middlewares/requestValidation.middleware.ts
+++ b/src/middlewares/requestValidation.middleware.ts
@@ -4,16 +4,17 @@ import {
 } from "@/zod/schemas/expressRequest";
 import { NextFunction, Response } from "express";
 import { ZodRawShape } from "zod";
+import { AuthenticatedRequest } from "./auth.middleware";
 
 export const requestValidationMiddleware = <
   TBody extends ZodRawShape = {},
   TQueryParams extends ZodRawShape = {},
   TParams extends ZodRawShape = {},
 >(
-  schema: ExpressRequestSchema<TBody, TQueryParams, TParams>,
+  schema: ExpressRequestSchema<TBody, TQueryParams, TParams> ,
 ) => {
   return (
-    req: TypedRequest<typeof schema>,
+    req: TypedRequest<typeof schema> & AuthenticatedRequest,
     res: Response,
     next: NextFunction,
   ) => {

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -1,4 +1,6 @@
-import authMiddleware from "@/middlewares/auth.middleware";
+import authMiddleware, {
+  AuthenticatedRequest,
+} from "@/middlewares/auth.middleware";
 import { getLeaderboard, getUserProfile } from "@/controllers/user.controller";
 import express from "express";
 
@@ -7,9 +9,10 @@ const userRouter = express.Router();
 userRouter.use(authMiddleware);
 
 // TODO: this is dummy route, remove it later
-userRouter.delete("/delete", (_req, res) =>
-  res.json({ message: "Hello, user!" }),
-);
+userRouter.delete("/delete", (_req: AuthenticatedRequest, res) => {
+  console.log(_req.user);
+  res.json({ message: "Hello, user!" });
+});
 userRouter.get("/my-profile", getUserProfile);
 userRouter.get("/leaderboard", getLeaderboard);
 

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -10,7 +10,6 @@ userRouter.use(authMiddleware);
 
 // TODO: this is dummy route, remove it later
 userRouter.delete("/delete", (_req: AuthenticatedRequest, res) => {
-  console.log(_req.user);
   res.json({ message: "Hello, user!" });
 });
 userRouter.get("/my-profile", getUserProfile);

--- a/src/zod/schemas/expressRequest.ts
+++ b/src/zod/schemas/expressRequest.ts
@@ -1,3 +1,4 @@
+import { AuthenticatedRequest } from "@/middlewares/auth.middleware";
 import { Request } from "express";
 import { z, ZodObject, ZodRawShape, ZodTypeAny } from "zod";
 
@@ -48,4 +49,4 @@ export type TypedRequest<T extends ExpressRequestSchema> = Request<
   any,
   z.infer<T["body"]>,
   z.infer<T["queryParams"]>
->;
+> & AuthenticatedRequest;


### PR DESCRIPTION
Integrate `TypedRequest`, `AuthenticatedRequest`, `authMiddleware`, and `requestValidationMiddleware`. With this PR, now, when writing controller, when using `TypedRequest` or `AuthenticatedRequest` as type for `req`, `req` will have `user?` property. The type of `user?` property is 
```ts
type user = {
    password: string;
    id: string;
    username: string;
    email: string;
    level: number;
    exp: number;
}
```

Yes, it's the same as `UserType` from `src/drizzle/schema.ts`. The point of this update is, now, in every controller which the endpoint/route of the controller require authentication, we can directly access the authenticated user that make the request. So whenever we need to access the `user.id`, `user.email`, etc of the requesting user, we can directly access it from `req.user`

But for this to work properly, make sure that in `req` type is either `AuthenticatedRequest` or `TypedRequest` and it's derivative. Also, since `req.user` contains the information of the authenticated user, in endpoints/routes that don't pass `authMiddleware` like `/register` and `/login`, the value of `req.user` in the controller would be `undefined`